### PR TITLE
Adjustments due to 'hide' behaviour

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = class Badge {
     this.opts = opts;
     this.generator = new BadgeGenerator(win, opts);
     this.initListeners();
-    this.win.on('close', () => { this.win = null; });
+    this.win.on('closed', () => { this.win = null; });
   }
 
   update(badgeNumber) {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const { nativeImage, ipcMain } = require('electron');
 const BadgeGenerator = require('./badge_generator.js');
 const badgeDescription = 'New notification';
 const UPDATE_BADGE_EVENT = 'update-badge';
+let currentOverlayIcon = { image: null, badgeDescription };
 
 module.exports = class Badge {
   constructor(win, opts = {}) {
@@ -10,16 +11,25 @@ module.exports = class Badge {
     this.generator = new BadgeGenerator(win, opts);
     this.initListeners();
     this.win.on('closed', () => { this.win = null; });
+    this.win.on('show', () => { this.win.setOverlayIcon(currentOverlayIcon.image, currentOverlayIcon.badgeDescription); });
   }
 
   update(badgeNumber) {
     if (badgeNumber) {
       this.generator.generate(badgeNumber).then((base64) => {
-        const image =  nativeImage.createFromDataURL(base64);
-        this.win.setOverlayIcon(image, badgeDescription);
+        const image = nativeImage.createFromDataURL(base64);
+        currentOverlayIcon = {
+          image,
+          badgeDescription
+        }
+        this.win.setOverlayIcon(currentOverlayIcon.image, currentOverlayIcon.badgeDescription);
       });
     } else {
-      this.win.setOverlayIcon(null, badgeDescription);
+      currentOverlayIcon = {
+        image: null,
+        badgeDescription
+      }
+      this.win.setOverlayIcon(currentOverlayIcon.image, currentOverlayIcon.badgeDescription);
     }
   }
 


### PR DESCRIPTION
Overriding 'close' behaviour to hide instead of close would stop badge from working properly. Instead, set window to null on 'closed' event to prevent this from happening.
Also, when window was restored, the overlay icon was lost, so it was needed to keep it and reset it on 'show' event