### PR TITLE
Create a blank canvas so the badge doesn't stretch

### DIFF
--- a/badge_generator.js
+++ b/badge_generator.js
@@ -72,6 +72,14 @@ module.exports = class BadgeGenerator {
     }
 
     img.draw();
-    return img.toDataURL();
+
+    // Create a blank 16x16 transparent canvas so that the badge doesn't stretch.
+    var blankCanvas = document.createElement('canvas');
+    blankCanvas.width = 16;
+    blankCanvas.height = 16;
+    var ctx = blankCanvas.getContext('2d');
+    ctx.drawImage(img, 16 - img.width, 16 - img.height)
+
+    return blankCanvas.toDataURL();
   }
 }


### PR DESCRIPTION
This PR creates a 16x16 transparent canvas where the badge is placed in to stop the badge from stretching to a full 16x16 image and creating blurry badges as reported in #8, which makes it impossible to create smaller badges then the 16x16 default. 
